### PR TITLE
Colorize rubySymbol and rubyBlock

### DIFF
--- a/colors/agnostic.vim
+++ b/colors/agnostic.vim
@@ -161,6 +161,8 @@ highlight rubyDefine   ctermbg=0 ctermfg=13 cterm=bold
 "        *rubyDefine   Ruby def
 " TODO Fix having to set the ctermbg here.  It is inheritting 8 from
 " somewhere.
+highlight rubySymbol   ctermfg=14 cterm=bold
+highlight rubyBlock    ctermfg=11 cterm=none
 
 " Vim Specific
 highlight vimCommand             ctermfg=15 cterm=bold


### PR DESCRIPTION
Make symbols cyan.  Make rubyBlock yellow.  At the moment, the places we see rubyBlock are in things like has_many.  Unfortunately it also colourizes some punctuation, but overall looks not too bad.
