### PR TITLE
Add custom highlighting for spelling mistakes.

### DIFF
--- a/colors/agnostic.vim
+++ b/colors/agnostic.vim
@@ -172,7 +172,7 @@ highlight FoldedColumn ctermbg=8 ctermfg=7  cterm=none
 highlight CursorColumn ctermbg=8
 highlight ColorColumn  ctermbg=8
 " Unfortunately we have to set term/cterm to none to remove underlines
-highlight CursorLine   term=none cterm=none ctermbg=8 
+highlight CursorLine   term=none cterm=none ctermbg=8
 
 " Ruby Specific
 
@@ -209,3 +209,9 @@ highlight markdownAutomaticLink ctermfg=12 cterm=none
 
 " Files
 highlight Directory ctermbg=2 ctermfg=15 cterm=bold
+
+" Spell checking
+hi SpellBad cterm=underline ctermfg=1 ctermbg=0
+hi SpellCap cterm=underline ctermfg=4 ctermbg=0
+hi SpellRare cterm=underline ctermfg=4 ctermbg=0
+hi SpellLocal cterm=underline ctermfg=6 ctermbg=0


### PR DESCRIPTION
Remove background and add underline. Use lighter colours.
Also works on the cursor line.

![screen shot 2015-03-08 at 18 20 29](https://cloud.githubusercontent.com/assets/3717128/6546962/f2f5c8ce-c5bf-11e4-8750-393ef410675f.png)
![screen shot 2015-03-08 at 18 20 50](https://cloud.githubusercontent.com/assets/3717128/6546963/f2fffbb4-c5bf-11e4-901d-39ec145e460f.png)
