### PR TITLE
Set the conventional g:colors_name variable

### DIFF
--- a/colors/agnostic.vim
+++ b/colors/agnostic.vim
@@ -1,3 +1,5 @@
+let g:colors_name="agnostic"
+
 " This scheme allows people to customize their colours in
 " their terminals.  The colours should follow these rules.
 "


### PR DESCRIPTION
Typing :colorscheme will return "agnostic" instead of "default".
See :h colorscheme.